### PR TITLE
feat: Set default encoding to UTF-8

### DIFF
--- a/src/github_bot_api/event.py
+++ b/src/github_bot_api/event.py
@@ -70,7 +70,7 @@ def accept_event(
   mime_type, parameters = get_mime_components(content_type)
   if mime_type != 'application/json':
     raise InvalidRequest(f'expected Content-Type: application/json, got {content_type}')
-  encoding = dict(parameters).get('encoding', 'ascii')
+  encoding = dict(parameters).get('encoding', 'UTF-8')
 
   if webhook_secret is not None:
     if signature_256:


### PR DESCRIPTION
Hi 👋 ,

Thanks for making this, the project has been really helpful for us to get up and running with working with Github Webhooks quickly and easily.

We've noticed that when PR comments that contain Emojis arrive it causes an exception to be raised:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 48: ordinal not in range(128)
  File "flask/app.py", line 2070, in wsgi_app
    response = self.full_dispatch_request()
  File "flask/app.py", line 1515, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "flask/app.py", line 1513, in full_dispatch_request
    rv = self.dispatch_request()
  File "flask/app.py", line 1499, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "github_bot_api/flask.py", line 14, in event_handler
    event = accept_event(
  File "github_bot_api/event.py", line 66, in accept_event
    json.loads(raw_body.decode(encoding)),
```

I believe this is because if the `encoding` is not set in the `Content-Type` header it defaults to ASCII and it looks like our Github webhooks don't have the `encoding` set:

```
POST /event-handler HTTP/1.1
Content-Type: application/json
````

So given that Github comments can have Emojis in them and Github doesn't seem to set the `encoding` in the `Content-Type` header I think it's best to default to `UTF-8` rather than `ASCII` ?

I've tried this on my application and it fixes the exception, let me know if you think there's a better way to handle it.