### PR TITLE
fix: ensure `iss` claim is a string

### DIFF
--- a/src/github_bot_api/token.py
+++ b/src/github_bot_api/token.py
@@ -59,7 +59,7 @@ def create_jwt(app_id: int, expires_in: int, private_key: str) -> TokenInfo:
 
     now = int(time.time())
     exp = now + expires_in
-    payload = {"iss": app_id, "iat": now, "exp": exp}
+    payload = {"iss": str(app_id), "iat": now, "exp": exp}
     token = jwt.encode(payload, private_key, algorithm="RS256")
     return TokenInfo(exp, "Bearer", token)
 


### PR DESCRIPTION
As of version v2.11.0 of PyJWT the `iss` claim is being validated as being a string. Ensure we are passing in a string instead of an int.

Ref: https://github.com/jpadilla/pyjwt/blob/697344d25990641b8b2aa85f0a60634b590b5702/CHANGELOG.rst?plain=1#L26